### PR TITLE
Add badges section

### DIFF
--- a/src/components/Badges.astro
+++ b/src/components/Badges.astro
@@ -1,0 +1,40 @@
+---
+import Badge from './Badge.astro';
+import { getLangFromUrl } from '../i18n/utils';
+
+const lang = getLangFromUrl(new URL(Astro.request.url));
+
+interface BadgeItem {
+	label: string;
+	link?: string;
+}
+
+const BADGES: Record<string, BadgeItem[]> = {
+	es: [
+		{ label: 'GitHub Foundations', link: 'https://www.credly.com/badges' },
+		{ label: 'Data Science', link: '#' },
+	],
+	en: [
+		{ label: 'GitHub Foundations', link: 'https://www.credly.com/badges' },
+		{ label: 'Data Science', link: '#' },
+	],
+};
+
+const badges = BADGES[lang] || BADGES.es;
+---
+
+<ul class="flex flex-wrap gap-4">
+	{
+		badges.map(badge => (
+			<li>
+				{badge.link ? (
+					<a href={badge.link} target="_blank" rel="noopener" class="inline-block">
+						<Badge>{badge.label}</Badge>
+					</a>
+				) : (
+					<Badge>{badge.label}</Badge>
+				)}
+			</li>
+		))
+	}
+</ul>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,6 +18,11 @@ const navItems = [
 		url: `/${lang}/#projects`,
 	},
 	{
+		title: t('nav.badges'),
+		label: 'insignias',
+		url: `/${lang}/#badges`,
+	},
+	{
 		title: t('nav.about'),
 		label: 'sobre-mi',
 		url: `/${lang}/#about-me`,

--- a/src/components/icons/Star.astro
+++ b/src/components/icons/Star.astro
@@ -1,0 +1,17 @@
+<svg
+	{...Astro.props}
+	xmlns="http://www.w3.org/2000/svg"
+	width="24"
+	height="24"
+	viewBox="0 0 24 24"
+	stroke-width="2"
+	stroke="currentColor"
+	fill="none"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+>
+	<path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+	<path
+		d="M12 17.75l-6.172 3.245l1.179-6.873l-4.993-4.868l6.9-1.002L12 2l3.086 6.252l6.9 1.002l-4.993 4.868l1.179 6.873z"
+	></path>
+</svg>

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -9,6 +9,7 @@ export const ui = {
 	en: {
 		'nav.experience': 'Experience',
 		'nav.projects': 'Projects',
+		'nav.badges': 'Badges',
 		'nav.about': 'About me',
 		'nav.contact': 'Contact',
 		'hero.available': 'Available for work',
@@ -31,6 +32,7 @@ export const ui = {
 		// Projects translations
 		'projects.code-button': 'Code',
 		'projects.preview-button': 'Preview',
+		'badges.title': 'Badges',
 		// Footer translations
 		'footer.rights': 'All rights reserved',
 		'footer.about': 'About me',
@@ -39,6 +41,7 @@ export const ui = {
 	es: {
 		'nav.experience': 'Experiencia',
 		'nav.projects': 'Proyectos',
+		'nav.badges': 'Insignias',
 		'nav.about': 'Sobre mí',
 		'nav.contact': 'Contacto',
 		'hero.available': 'Disponible para trabajar',
@@ -61,6 +64,7 @@ export const ui = {
 		//Proyectos
 		'projects.code-button': 'Código',
 		'projects.preview-button': 'Vista previa',
+		'badges.title': 'Insignias',
 		//Footer
 		'footer.rights': 'Todos los derechos reservados',
 		'footer.about': 'Sobre mí',

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,6 +1,7 @@
 ---
 import CodeIcon from '../../components/icons/Code.astro';
 import ProfileCheckIcon from '../../components/icons/ProfileCheck.astro';
+import StarIcon from '../../components/icons/Star.astro';
 import Layout from '../../layouts/Layout.astro';
 import Experience from '../../components/Experience.astro';
 import SectionContainer from '../../components/SectionContainer.astro';
@@ -8,6 +9,7 @@ import BriefCaseIcon from '../../components/icons/Briefcase.astro';
 import Projects from '../../components/Projects.astro';
 import TitleSection from '../../components/TitleSection.astro';
 import AboutMe from '../../components/AboutMe.astro';
+import Badges from '../../components/Badges.astro';
 import Hero from '../../components/Hero.astro';
 ---
 
@@ -36,6 +38,14 @@ import Hero from '../../components/Hero.astro';
 				Projects
 			</TitleSection>
 			<Projects />
+		</SectionContainer>
+
+		<SectionContainer id="badges">
+			<TitleSection>
+				<StarIcon class="size-7" />
+				Badges
+			</TitleSection>
+			<Badges />
 		</SectionContainer>
 
 		<SectionContainer id="about-me">

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,6 +1,7 @@
 ---
 import CodeIcon from '../../components/icons/Code.astro';
 import ProfileCheckIcon from '../../components/icons/ProfileCheck.astro';
+import StarIcon from '../../components/icons/Star.astro';
 import Layout from '../../layouts/Layout.astro';
 import Experience from '../../components/Experience.astro';
 import SectionContainer from '../../components/SectionContainer.astro';
@@ -8,6 +9,7 @@ import BriefCaseIcon from '../../components/icons/Briefcase.astro';
 import Projects from '../../components/Projects.astro';
 import TitleSection from '../../components/TitleSection.astro';
 import AboutMe from '../../components/AboutMe.astro';
+import Badges from '../../components/Badges.astro';
 import Hero from '../../components/Hero.astro';
 ---
 
@@ -36,6 +38,14 @@ import Hero from '../../components/Hero.astro';
 				Proyectos
 			</TitleSection>
 			<Projects />
+		</SectionContainer>
+
+		<SectionContainer id="badges">
+			<TitleSection>
+				<StarIcon class="size-7" />
+				Insignias
+			</TitleSection>
+			<Badges />
 		</SectionContainer>
 
 		<SectionContainer id="about-me">


### PR DESCRIPTION
## Summary
- create star icon
- create reusable Badges component
- extend translations with badges entries
- update navigation to link to new badges section
- add badges area to Spanish and English homepages

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a726b2d54832db1d9e3b699ff26f6